### PR TITLE
Update install script to use lowercase package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ The function recieves 2 arguments: The knobs instance referece and the (auto)gen
 ## Install:
 
 ```
-npm i @yaireo/Knobs
+npm i @yaireo/knobs
 ```
 
 **CDN source:**


### PR DESCRIPTION
```sh
❯ npm i @yaireo/Knobs
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/@yaireo%2fKnobs - Not found
npm ERR! 404 
npm ERR! 404  '@yaireo/Knobs@*' is not in this registry.
npm ERR! 404 This package name is not valid, because 
npm ERR! 404  1. name can no longer contain capital letters
```